### PR TITLE
update css for the chevron to set position absolutely instead of relativ

### DIFF
--- a/scripts/components/header/nav/nav.styles.scss
+++ b/scripts/components/header/nav/nav.styles.scss
@@ -35,10 +35,11 @@
       border-width: 0 8px 8px 0;
       display: inline-block;
       padding: 12px;
-      transform: rotate(-135deg);
-      -webkit-transform: rotate(-135deg);
-      position: relative;
-      top: 30%;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%) rotate(-135deg);
+      -webkit-transform: translate(-50%, -50%) rotate(-135deg);
     }
   }
   transition: all 0.3s;


### PR DESCRIPTION
closes #107 

Please ensure that Mozilla is rendering the Chevron correctly and also that other browsers do too =)